### PR TITLE
Fix Linux builds by only enabling libc++ on macOS

### DIFF
--- a/heif-decoder/build.rs
+++ b/heif-decoder/build.rs
@@ -10,7 +10,7 @@ fn main() {
 	if env::var("CARGO_CFG_TARGET_OS").unwrap() == "android" {
 		// if we don't bundle libc++ this causes problems on android
 		println!("cargo:rustc-link-lib=static:-bundle=c++");
-	} else if env::var("CARGO_CFG_TARGET_OS").unwrap() != "windows" {
+	} else if env::var("CARGO_CFG_TARGET_OS").unwrap() == "macos" {
 		println!("cargo:rustc-link-lib=c++");
 	}
 
@@ -105,15 +105,16 @@ fn config_cmake_for_ios(config: &mut Config) {
 }
 
 fn config_cmake_for_libcxx(config: &mut Config) {
-	// Force CMake to use libc++ instead of libstdc++
-	config.define("CMAKE_CXX_FLAGS", "-stdlib=libc++");
-	config.define("CMAKE_EXE_LINKER_FLAGS", "-stdlib=libc++");
-	config.define("CMAKE_SHARED_LINKER_FLAGS", "-stdlib=libc++");
+	if env::var("CARGO_CFG_TARGET_OS").unwrap() == "macos" {
+		// Force CMake to use libc++ instead of libstdc++
+		config.define("CMAKE_CXX_FLAGS", "-stdlib=libc++");
+		config.define("CMAKE_EXE_LINKER_FLAGS", "-stdlib=libc++");
+		config.define("CMAKE_SHARED_LINKER_FLAGS", "-stdlib=libc++");
 
-	// Ensure we're using clang++ for consistency
-	config.define("CMAKE_CXX_COMPILER", "clang++");
-	config.define("CMAKE_C_COMPILER", "clang");
-
+		// Ensure we're using clang++ for consistency
+		config.define("CMAKE_CXX_COMPILER", "clang++");
+		config.define("CMAKE_C_COMPILER", "clang");
+	}
 	// This was causing issues on the windows runner and we don't care about documentation
 	config.define("CMAKE_DISABLE_FIND_PACKAGE_Doxygen", "TRUE");
 }


### PR DESCRIPTION
Right now build.rs in heif-decoder forces libc++ for all platforms.

Some Linux distributions (for example Artix) do not ship libc++ by default and instead use libstdc++, causing builds to fail during CMake compiler checks.

Example failure:
```
  CMake Error at /usr/share/cmake/Modules/CMakeTestCXXCompiler.cmake:73 (message):
    The C++ compiler

      "/usr/sbin/clang++"

    is not able to compile a simple test program.

    It fails with the following output:

      Change Dir: '/home/axjp/filen-rs/target/debug/build/heif-decoder-2bff953f36aa280d/out/build/CMakeFiles/CMakeScratch/TryCompile-uWsv8f'
      
      Run Build Command(s): /usr/sbin/cmake -E env VERBOSE=1 /usr/sbin/make -f Makefile cmTC_f31b4/fast
      /usr/sbin/make  -f CMakeFiles/cmTC_f31b4.dir/build.make CMakeFiles/cmTC_f31b4.dir/build
      make[1]: Entering directory '/home/axjp/filen-rs/target/debug/build/heif-decoder-2bff953f36aa280d/out/build/CMakeFiles/CMakeScratch/TryCompile-uWsv8f'
      Building CXX object CMakeFiles/cmTC_f31b4.dir/testCXXCompiler.cxx.o
      /usr/sbin/clang++   -stdlib=libc++  -MD -MT CMakeFiles/cmTC_f31b4.dir/testCXXCompiler.cxx.o -MF CMakeFiles/cmTC_f31b4.dir/testCXXCompiler.cxx.o.d -o CMakeFiles/cmTC_f31b4.dir/testCXXCompiler.cxx.o -c /home/axjp/filen-rs/target/debug/build/heif-decoder-2bff953f36aa280d/out/build/CMakeFiles/CMakeScratch/TryCompile-uWsv8f/testCXXCompiler.cxx
      Linking CXX executable cmTC_f31b4
      /usr/sbin/cmake -E cmake_link_script CMakeFiles/cmTC_f31b4.dir/link.txt --verbose=1
      /usr/bin/ld: cannot find -lc++: No such file or directory
      clang++: error: linker command failed with exit code 1 (use -v to see invocation)
      /usr/sbin/clang++ -stdlib=libc++  -stdlib=libc++  CMakeFiles/cmTC_f31b4.dir/testCXXCompiler.cxx.o -o cmTC_f31b4
      make[1]: *** [CMakeFiles/cmTC_f31b4.dir/build.make:103: cmTC_f31b4] Error 1
      make[1]: Leaving directory '/home/axjp/filen-rs/target/debug/build/heif-decoder-2bff953f36aa280d/out/build/CMakeFiles/CMakeScratch/TryCompile-uWsv8f'
      make: *** [Makefile:134: cmTC_f31b4/fast] Error 2
```

This PR restricts libc++ configuration to macOS only, where it is the
expected default C++ standard library.

## Result

* macOS behavior unchanged
* Linux builds now work with the default libstdc++ toolchain
* avoids unnecessary hard dependency on libc++
